### PR TITLE
Pad stringification of exponent on systems that always use more than 2 digits

### DIFF
--- a/t/latex.t
+++ b/t/latex.t
@@ -17,6 +17,11 @@ $
 LATEX
 chomp $latex1;
 
+# Determine number of digits in exponents beyond the libc 'standard' of two
+# and pad out the expected result.
+my $zero = sprintf '%E', 0;
+my ($pad) = $zero =~ m/E\+00(\d+)$/;
+$latex1 =~ s/([eE])([+-])(\d\d)/$1$2$pad$3/g if defined $pad;
 
     my $a = Math::MatrixReal->new_from_cols([[ 1.41E-05, 6.82E-06, 3.18E-06 ],[1,3,4]]);
     eq_or_diff( lc $a->as_latex, lc $latex1, 'as_latex seems to work');

--- a/t/stringify.t
+++ b/t/stringify.t
@@ -4,12 +4,17 @@ use lib File::Spec->catfile("..","lib");
 use Math::MatrixReal;
 do 'funcs.pl';
 
+# Determine number of digits in exponents beyond the libc 'standard' of two
+# and pad out the expected result.
+my $zero = sprintf '%E', 0;
+my ($pad) = $zero =~ m/E\+00(\d+)$/;
+
 my $correct=<<ERE;
 [  1.000000000000E+00  0.000000000000E+00  0.000000000000E+00 ]
 [  0.000000000000E+00  2.000000000000E+00  0.000000000000E+00 ]
 [  0.000000000000E+00  0.000000000000E+00  3.000000000000E+00 ]
 ERE
-
+$correct =~ s/([eE])([+-])(\d\d)/$1$2$pad$3/g if defined $pad;
 my $matrix = Math::MatrixReal->new_diag( [ 1, 2, 3] );
 my $str = "$matrix";
 ok( $str eq $correct, 'stringification');
@@ -21,5 +26,6 @@ my $correct2=<<ERE;
 
 Blah blah blah
 ERE
+$correct2 =~ s/([eE])([+-])(\d\d)/$1$2$pad$3/g if defined $pad;
 my $stuff = $matrix . "\nBlah blah blah\n";
 ok( $stuff eq $correct2, 'implied stringification with concat');

--- a/t/tridiag.t
+++ b/t/tridiag.t
@@ -5,6 +5,9 @@ use Math::MatrixReal;
 use strict;
 do 'funcs.pl';
 
+my $zero = sprintf '%E', 0;
+my ($pad) = $zero =~ /E00(\d+)$/;
+
 my $b = Math::MatrixReal->new_from_string(<<XXX);
 [ 1 1 0 0 ]
 [ 1 2 2 0 ]
@@ -31,6 +34,12 @@ my $correct = <<'MAT';
 [  0.000000000000E+00  4.000000000000E+00  3.000000000000E+00  9.000000000000E+00 ]
 [  0.000000000000E+00  0.000000000000E+00  2.000000000000E+00  4.000000000000E+00 ]
 MAT
+
+# Determine number of digits in exponents beyond the libc 'standard' of two
+# and pad out the expected result.
+my $zero = sprintf '%E', 0;
+my ($pad) = $zero =~ m/E\+00(\d+)$/;
+$correct =~ s/([eE])([+-])(\d\d)/$1$2$pad$3/g if defined $pad;
 
 ok( "$matrix" eq $correct, 'new_tridiag' );
 

--- a/t/yacas.t
+++ b/t/yacas.t
@@ -7,7 +7,15 @@ do 'funcs.pl';
 
 my ($a,$b);
 $a = Math::MatrixReal->new_from_cols([[ 1.41E-05, 6.82E-06, 3.18E-06 ],[1,3,4]]);
-ok($a->as_yacas eq '{{1.41e-05,1},{6.82e-06,3},{3.18e-06,4}}', 'as_yacas works' );
+my $correct = '{{1.41e-05,1},{6.82e-06,3},{3.18e-06,4}}';
+
+# Determine number of digits in exponents beyond the libc 'standard' of two
+# and pad out the expected result.
+my $zero = sprintf '%E', 0;
+my ($pad) = $zero =~ m/E\+00(\d+)$/;
+$correct =~ s/([eE])([+-])(\d\d)/$1$2$pad$3/g if defined $pad;
+
+ok($a->as_yacas eq $correct, 'as_yacas works' );
 
 $b = Math::MatrixReal->new_from_cols([[ 1.234, 5.678, 9.1011],[1,2,3]] );
 my $s = $b->as_yacas( ( format => "%.2f", align => "l",name => "A" ) );


### PR DESCRIPTION
Perl builds on windows default to using *printf from Microsoft's MSVCRT. Microsoft chose a default of three digit exponents rather than the 2 digit ISO-C99 standard with the %e or %E conversion specifiers for doubles.

Check if a '0' generates an exponent longer that two digits and pad the expected test output strings appropriate.
