### PR TITLE
fix pod error

### DIFF
--- a/lib/Math/MatrixReal.pm
+++ b/lib/Math/MatrixReal.pm
@@ -4027,8 +4027,6 @@ C<$adjoint = $matrix-E<gt>adjoint();>
 The adjoint is just the transpose of the cofactor matrix. This method is 
 just an alias for C< ~($matrix-E<gt>cofactor)>.
 
-=back
-
 =item *
 
 C<$part_of_matrix = $matrix-E<gt>submatrix(x1,y1,x2,Y2);>


### PR DESCRIPTION
The following errors were encountered while parsing the POD, around
line 4032:

	'=item' outside of any '=over'

Removing the '=back' directive prior this '=item' seems bring the
expected formating for the documentation.