### PR TITLE
fix typos landing in documentation

### DIFF
--- a/lib/Math/MatrixReal.pm
+++ b/lib/Math/MatrixReal.pm
@@ -4033,7 +4033,7 @@ just an alias for C< ~($matrix-E<gt>cofactor)>.
 
 C<$part_of_matrix = $matrix-E<gt>submatrix(x1,y1,x2,Y2);>
 
-Submatrix permit to select only part of existing matrix in order to produce a new one.
+Submatrix permits one to select only part of existing matrix in order to produce a new one.
 This method take four arguments to define a selection area:
 
 =over 6
@@ -4344,7 +4344,7 @@ The primary property of an eigenvalue I<l> and an eigenvector
 B<x> is of course that: B<M> * B<x> = I<l> * B<x>.
 
 The method uses a Householder reduction to tridiagonal form
-followed by a QL algoritm with implicit shifts on this
+followed by a QL algorithm with implicit shifts on this
 tridiagonal. (The tridiagonal matrix is kept internally
 in a compact form in this routine to save memory.)
 In fact, this routine wraps the householder() and
@@ -4364,7 +4364,7 @@ the I<n> by I<n> real I<symmetric> matrix B<M> contained
 in $matrix to tridiagonal form.
 On output, B<T> is a symmetric tridiagonal matrix (only
 diagonal and off-diagonal elements are non-zero) and B<Q>
-is an I<orthogonal> matrix performing the tranformation
+is an I<orthogonal> matrix performing the transformation
 between B<M> and B<T> (C<$M == $Q * $T * ~$Q>).
 
 =item *
@@ -5350,7 +5350,7 @@ Example:
 
 Boolean test
 
-Tests wether there is at least one non-zero element in the matrix.
+Tests whether there is at least one non-zero element in the matrix.
 
 Example:
 
@@ -5360,7 +5360,7 @@ Example:
 
 Negated boolean test
 
-Tests wether the matrix contains only zero's.
+Tests whether the matrix contains only zero's.
 
 Examples:
 


### PR DESCRIPTION
Good day,

Sorry I haven't reported them earlier, here are a few typo fixes.  They have been caught by lintian on the manual page resulting from the conversion from POD.

Have a nice day.  :)